### PR TITLE
Add option to disable trusting incoming spans

### DIFF
--- a/lib/rack/tracer.rb
+++ b/lib/rack/tracer.rb
@@ -13,17 +13,18 @@ module Rack
     # @param on_start_span [Proc, nil] A callback evaluated after a new span is created.
     # @param errors [Array<Class>] An array of error classes to be captured by the tracer
     #        as errors. Errors are **not** muted by the middleware, they're re-raised afterwards.
-    def initialize(app, tracer: OpenTracing.global_tracer, on_start_span: nil, errors: [StandardError])
+    def initialize(app, tracer: OpenTracing.global_tracer, on_start_span: nil, trust_incoming_span: true, errors: [StandardError])
       @app = app
       @tracer = tracer
       @on_start_span = on_start_span
+      @trust_incoming_span = trust_incoming_span
       @errors = errors
     end
 
     def call(env)
       method = env[REQUEST_METHOD]
 
-      context = @tracer.extract(OpenTracing::FORMAT_RACK, env)
+      context = @tracer.extract(OpenTracing::FORMAT_RACK, env) if @trust_incoming_span
       span = @tracer.start_span(method,
         child_of: context,
         tags: {

--- a/spec/rack/tracer_spec.rb
+++ b/spec/rack/tracer_spec.rb
@@ -72,6 +72,30 @@ RSpec.describe Rack::Tracer do
     end
   end
 
+  context 'when already traced but untrusted request' do
+    it 'starts a new trace' do
+      respond_with(trust_incoming_span: false) { ok_response }
+
+      expect(logger.calls.map(&:first)).to eq([
+        "Span [#{method}] started",
+        "Span [#{method}] finished"
+      ])
+    end
+
+    it 'does not pass incoming span to downstream' do
+      respond_with(trust_incoming_span: false) do |env|
+        expect(env['rack.span']).to be_a(Logasm::Tracer::Span)
+        expect(env['rack.span'].context.parent_id).to be_nil
+        ok_response
+      end
+    end
+
+    it 'calls on_start_span callback' do
+      respond_with(trust_incoming_span: false) { ok_response }
+      expect(on_start_span).to have_received(:call).with(instance_of(Logasm::Tracer::Span))
+    end
+  end
+
   context 'when an exception bubbles-up through the middlewares' do
     it 'finishes the span' do
       expect { respond_with { |env| raise Timeout::Error } }.to raise_error { |_|
@@ -105,8 +129,8 @@ RSpec.describe Rack::Tracer do
     end
   end
 
-  def respond_with(&app)
-    middleware = described_class.new(app, tracer: tracer, on_start_span: on_start_span)
+  def respond_with(trust_incoming_span: true, &app)
+    middleware = described_class.new(app, tracer: tracer, on_start_span: on_start_span, trust_incoming_span: trust_incoming_span)
     middleware.call(env)
   end
 


### PR DESCRIPTION
It might be a security weakness to simply always trust and extract parent span information from all incoming requests. Depending on the way how the Rack-based app is deployed the header in the request could be spoofed by any client without protections.