### PR TITLE
Generate operation name from Rails controllers

### DIFF
--- a/lib/rack/tracer.rb
+++ b/lib/rack/tracer.rb
@@ -77,7 +77,11 @@ module Rack
     private
 
     def route_from_env(env)
-      env['sinatra.route']
+      if (sinatra_route = env['sinatra.route'])
+        sinatra_route
+      elsif (rails_controller = env['action_controller.instance'])
+        "#{env[REQUEST_METHOD]} #{rails_controller.controller_name}/#{rails_controller.action_name}"
+      end
     end
   end
 end

--- a/spec/rack/tracer_spec.rb
+++ b/spec/rack/tracer_spec.rb
@@ -38,6 +38,24 @@ RSpec.describe Rack::Tracer do
         expect(span.operation_name).to eq(route)
       end
     end
+
+    context 'when env has action_controller.instance set' do
+      let(:route) { 'POST users/create' }
+
+      before do
+        # rubocop:disable RSpec/VerifiedDoubles - not going to pull the whole rails as devel dependency for this
+        env['action_controller.instance'] = double('UsersController',
+                                                   controller_name: 'users',
+                                                   action_name: 'create')
+        # rubocop:enable RSpec/VerifiedDoubles
+      end
+
+      it 'adds the controller/action to operation name' do
+        respond_with { ok_response }
+        span = tracer.spans.last
+        expect(span.operation_name).to eq(route)
+      end
+    end
   end
 
   context 'when a new request' do


### PR DESCRIPTION
When trying the rack middleware with Rails, I've noticed there is no way how to quickly distinquish between the traces. Therefore, I've added additional operation_name based on controller and action that handled the requests, when available.