### PR TITLE
Add grape route information

### DIFF
--- a/lib/rack/tracer.rb
+++ b/lib/rack/tracer.rb
@@ -81,6 +81,17 @@ module Rack
         sinatra_route
       elsif (rails_controller = env['action_controller.instance'])
         "#{env[REQUEST_METHOD]} #{rails_controller.controller_name}/#{rails_controller.action_name}"
+      elsif (grape_route_args = env['grape.routing_args'] || env['rack.routing_args'])
+        grape_route_from_args(grape_route_args)
+      end
+    end
+
+    def grape_route_from_args(route_args)
+      route_info = route_args[:route_info]
+      if route_info.respond_to?(:path)
+        route_info.path
+      elsif (rack_route_options = route_info.instance_variable_get(:@options))
+        rack_route_options[:path]
       end
     end
   end

--- a/spec/rack/tracer_spec.rb
+++ b/spec/rack/tracer_spec.rb
@@ -56,6 +56,41 @@ RSpec.describe Rack::Tracer do
         expect(span.operation_name).to eq(route)
       end
     end
+
+    context 'when env has grape routing args set' do
+      let(:route) { 'POST /users/:id' }
+
+      before do
+        # rubocop:disable RSpec/VerifiedDoubles
+        env['grape.routing_args'] = { route_info: double(path: route) }
+        # rubocop:enable RSpec/VerifiedDoubles
+      end
+
+      it 'adds the route path to operation name' do
+        respond_with { ok_response }
+        span = tracer.spans.last
+        expect(span.operation_name).to eq(route)
+      end
+    end
+
+    context 'when env has grape rack routing args set' do
+      let(:route) { 'POST /users/:id' }
+
+      before do
+        class RouteInfo
+          attr_accessor :options
+        end
+        info = RouteInfo.new
+        info.options = { path: route }
+        env['rack.routing_args'] = { route_info: info }
+      end
+
+      it 'adds the route path to operation name' do
+        respond_with { ok_response }
+        span = tracer.spans.last
+        expect(span.operation_name).to eq(route)
+      end
+    end
   end
 
   context 'when a new request' do


### PR DESCRIPTION
Adds grape route information similar to sinatra and rails.  These changes breaking out into an additional `grape_route_from_args` method to avoid a cyclomatic complexity rubocop warning.