### PR TITLE
Adds error tag when http responses are >= 400

### DIFF
--- a/lib/rack/tracer.rb
+++ b/lib/rack/tracer.rb
@@ -52,6 +52,9 @@ module Rack
 
       @app.call(env).tap do |status_code, _headers, _body|
         span.set_tag('http.status_code', status_code)
+        if status_code >= 400
+          span.set_tag('error', true)
+        end
 
         route = route_from_env(env)
         span.operation_name = route if route

--- a/spec/rack/tracer_spec.rb
+++ b/spec/rack/tracer_spec.rb
@@ -232,6 +232,17 @@ RSpec.describe Rack::Tracer do
     end
   end
 
+  context 'when the rack app fails with http errors' do
+    let(:bad_response) { [400, { 'Content-Type' => 'application/json' }, ['{"ok": false}']] }
+
+    it 'reports the request as an error' do
+      respond_with { bad_response }
+      span = tracer.spans.last
+      expect(span.operation_name).to eq(method)
+      expect(span.tags).to include('error' => true)
+    end
+  end
+
   def respond_with(trust_incoming_span: true, &app)
     middleware = described_class.new(
       app,


### PR DESCRIPTION
When I encounter HTTP status errors I would like them to be reported upstream with `error` tags instead of having to segment traces by http status code. 